### PR TITLE
Update ev00C2 and ev00E2

### DIFF
--- a/SADX-cutscene-decompilation/Big/ev00E2_b_outro.cpp
+++ b/SADX-cutscene-decompilation/Big/ev00E2_b_outro.cpp
@@ -4,6 +4,7 @@
 
 PVMEntry texTbl_ev00E2[] = {
 	(char*)("FROG"), &texlist_frog,
+	(char*)("SHAPE_FROG"), &texlist_shape_frog,
 	(char*)("TR2CRASH"), &texlist_tr2crash,
 	0
 };

--- a/SADX-cutscene-decompilation/E102/ev00C2_e_escapecarrier.cpp
+++ b/SADX-cutscene-decompilation/E102/ev00C2_e_escapecarrier.cpp
@@ -3,6 +3,7 @@
 #include "SADXEventVariables.h"
 
 PVMEntry texTbl_ev00C2[] = {
+	(char*)("VER1_WING"), &VER1_WING_TEXLIST,
 	(char*)("VER2_WING"), &VER2_WING_TEXLIST,
 	0
 };


### PR DESCRIPTION
Fixes ev00C2 and ev00E2 crashing because of a missing texture.
Those are the last ones that have a texture missing i think.